### PR TITLE
Add dummy SECRET_KEY to testsettings.py

### DIFF
--- a/testsettings.py
+++ b/testsettings.py
@@ -8,3 +8,6 @@ DATABASES = {
 INSTALLED_APPS = (
     'myproject',
 )
+
+
+SECRET_KEY = 'abcde12345'


### PR DESCRIPTION
Django 1.5 raises `ImproperlyConfigured` with "The SECRET_KEY setting must not be empty."
